### PR TITLE
Fix CI by adding missing catkin-pkg-modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -493,6 +493,8 @@ matrix:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install EmPy

--- a/.travis.yml
+++ b/.travis.yml
@@ -198,7 +198,7 @@ matrix:
       env: JOB_TYPE=external_prerelease
       before_script:
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo apt-get install -y python3-pip python3-setuptools  python3-catkin-pkg-modules
         - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job
@@ -301,7 +301,7 @@ matrix:
       env: JOB_TYPE=external_prerelease
       before_script:
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job

--- a/.travis.yml
+++ b/.travis.yml
@@ -487,7 +487,7 @@ matrix:
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install EmPy
         # install catkin for test results
         - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
@@ -511,7 +511,7 @@ matrix:
       env: JOB_TYPE=external_prerelease
       before_script:
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install EmPy vcstool
         - python setup.py install
         - mkdir job && cd job

--- a/.travis.yml
+++ b/.travis.yml
@@ -198,7 +198,7 @@ matrix:
       env: JOB_TYPE=external_prerelease
       before_script:
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools  python3-catkin-pkg-modules
+        - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job
@@ -235,7 +235,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
-        - sudo apt-get install python3-vcstool -y
+        - sudo apt-get install python3-vcstool python3-catkin-pkg-modules -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -285,6 +285,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
+        - sudo apt-get install python3-catkin-pkg-modules -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm

--- a/.travis.yml
+++ b/.travis.yml
@@ -338,7 +338,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
-        - sudo apt-get install python3-vcstool -y
+        - sudo apt-get install python3-vcstool python3-catkin-pkg-modules -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -388,6 +388,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
+        - sudo apt-get install python3-catkin-pkg-modules -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -404,7 +405,7 @@ matrix:
       env: JOB_TYPE=external_prerelease
       before_script:
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip  python3-setuptools
+        - sudo apt-get install -y python3-pip  python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
-        - sudo apt-get install python3-vcstool -y
+        - sudo apt-get install python3-vcstool python3-catkin-pkg-modules -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
-        - sudo apt-get install python3-vcstool python3-catkin-pkg-modules -y
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -197,6 +197,8 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
@@ -235,7 +237,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
-        - sudo apt-get install python3-vcstool python3-catkin-pkg-modules -y
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -339,7 +341,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
-        - sudo apt-get install python3-vcstool python3-catkin-pkg-modules -y
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -443,7 +445,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
-        - sudo apt-get install python-vcstool python3-catkin-pkg-modules -y
+        - sudo apt-get install python-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm

--- a/.travis.yml
+++ b/.travis.yml
@@ -303,6 +303,8 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
@@ -407,6 +409,8 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip  python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
@@ -513,6 +517,8 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install EmPy vcstool

--- a/.travis.yml
+++ b/.travis.yml
@@ -442,7 +442,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
-        - sudo apt-get install python-vcstool -y
+        - sudo apt-get install python-vcstool python3-catkin-pkg-modules -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -62,7 +62,7 @@ RUN pip3 install -U setuptools
 @[if ros_version == 2]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ros-@(rosdistro_name)-ros-workspace
 @[end if]@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache python3-catkin-pkg-modules
 
 @(TEMPLATE(
     'snippet/set_environment_variables.Dockerfile.em',

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -16,8 +16,6 @@ import os
 import shutil
 import subprocess
 
-from catkin_pkg.packages import find_packages
-
 
 def ensure_workspace_exists(workspace_root):
     # ensure that workspace exists
@@ -42,37 +40,6 @@ def clean_workspace(workspace_root):
     test_results_dir = os.path.join(workspace_root, 'test_results')
     if os.path.exists(test_results_dir):
         shutil.rmtree(test_results_dir)
-
-
-def call_abi_checker(workspace_root, ros_version, rosdistro_name, env):
-    # TODO: pkgs detection, code based on create_devel_task_generator.py
-    condition_context = {}
-    condition_context['ROS_DISTRO'] = rosdistro_name
-    condition_context['ROS_VERSION'] = ros_version
-    condition_context['ROS_PYTHON_VERSION'] = \
-        (env or os.environ).get('ROS_PYTHON_VERSION')
-    pkgs = {}
-    for ws_root in workspace_root:
-        source_space = os.path.join(ws_root, 'src')
-        ws_pkgs = find_packages(source_space)
-        for pkg in ws_pkgs.values():
-            pkg.evaluate_conditions(condition_context)
-        pkgs.update(ws_pkgs)
-    pkg_names = [pkg.name for pkg in pkgs.values()]
-    assert(pkg_names), 'No packages found in the workspace'
-
-    assert(len(workspace_root) == 1), 'auto-abi tool needs the implementation of multiple local-dir'
-    cmd = ['ROS_DISTRO=' + rosdistro_name + ' ' +
-           'auto-abi.py ' +
-           '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
-           '--new-type ros-ws --new ' + os.path.join(workspace_root[0], 'install_isolated') + ' ' +
-           '--report-dir ' + workspace_root[0] + ' ' +
-           '--no-fail-if-empty ' +
-           '--display-exec-time'
-           ]
-    print("Invoking '%s'" % (cmd))
-    return subprocess.call(
-        cmd, shell=True, stderr=subprocess.STDOUT, env=env)
 
 
 def call_build_tool(

--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -32,6 +32,7 @@ from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.argument import add_argument_testing
 from ros_buildfarm.common import get_binary_package_versions
 from ros_buildfarm.common import get_distribution_repository_keys
@@ -57,6 +58,7 @@ def main(argv=sys.argv[1:]):
     add_argument_env_vars(parser)
     add_argument_install_packages(parser)
     add_argument_ros_version(parser)
+    add_argument_run_abichecker(parser)
     add_argument_testing(parser)
     parser.add_argument(
         '--workspace-root', nargs='+',
@@ -120,6 +122,7 @@ def main(argv=sys.argv[1:]):
         'dependency_versions': [],
 
         'testing': args.testing,
+        'run_abichecker': args.run_abichecker,
         'workspace_root': mapped_workspaces[-1][1],
         'parent_result_space': [mapping[1] for mapping in mapped_workspaces[:-1]],
     }

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -16,17 +16,50 @@
 
 import argparse
 import os
+import subprocess
 import sys
+
+from catkin_pkg.packages import find_packages
 
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import Scope
-from ros_buildfarm.workspace import call_abi_checker
 from ros_buildfarm.workspace import call_build_tool
 from ros_buildfarm.workspace import clean_workspace
 from ros_buildfarm.workspace import ensure_workspace_exists
+
+
+def call_abi_checker(workspace_root, ros_version, rosdistro_name, env):
+    # TODO: pkgs detection, code based on create_devel_task_generator.py
+    condition_context = {}
+    condition_context['ROS_DISTRO'] = rosdistro_name
+    condition_context['ROS_VERSION'] = ros_version
+    condition_context['ROS_PYTHON_VERSION'] = \
+        (env or os.environ).get('ROS_PYTHON_VERSION')
+    pkgs = {}
+    for ws_root in workspace_root:
+        source_space = os.path.join(ws_root, 'src')
+        ws_pkgs = find_packages(source_space)
+        for pkg in ws_pkgs.values():
+            pkg.evaluate_conditions(condition_context)
+        pkgs.update(ws_pkgs)
+    pkg_names = [pkg.name for pkg in pkgs.values()]
+    assert(pkg_names), 'No packages found in the workspace'
+
+    assert(len(workspace_root) == 1), 'auto-abi tool needs the implementation of multiple local-dir'
+    cmd = ['ROS_DISTRO=' + rosdistro_name + ' ' +
+           'auto-abi.py ' +
+           '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
+           '--new-type ros-ws --new ' + os.path.join(workspace_root[0], 'install_isolated') + ' ' +
+           '--report-dir ' + workspace_root[0] + ' ' +
+           '--no-fail-if-empty ' +
+           '--display-exec-time'
+           ]
+    print("Invoking '%s'" % (cmd))
+    return subprocess.call(
+        cmd, shell=True, stderr=subprocess.STDOUT, env=env)
 
 
 def main(argv=sys.argv[1:]):

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 
 from catkin_pkg.packages import find_packages
-
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_ros_version


### PR DESCRIPTION
catkin_pkg module is being used in build_and_install.py script. The CI needs to install the python modules in different places to keep things working. 